### PR TITLE
Set pipefail for align_transcripts_to_genome

### DIFF
--- a/JAFFA_stages.groovy
+++ b/JAFFA_stages.groovy
@@ -492,7 +492,7 @@ align_transcripts_to_genome = {
     produce(branch+"_genome.psl") {
         from(".fusions.fa") {
             exec """
-                $blat $genomeFasta $input1 -minScore=$minScore $output 2>&1 | tee ${output.dir}/log_genome_blat
+                set -o pipefail; $blat $genomeFasta $input1 -minScore=$minScore $output 2>&1 | tee ${output.dir}/log_genome_blat
             ""","align_transcripts_to_genome"
         }
     }


### PR DESCRIPTION
## Fix

Without pipefail, the return code of the command is the exit code
of the last command, i.e. the `tee` command in this case [1].

## Issue

This is a minor issue, but I spent an hour tracking it down and I hope it will save someone the same time in the future. I ran into this issue because the final results step was failing because an intermediate file was empty. The underlying cause was a lack of memory which showed up as

```
================================= Stage get_final_list (MCF7-demo) =================================

...

> options(echo=FALSE)
Error in read.table(file = file, header = header, sep = sep, quote = quote,  :
  no lines available in input
Calls: read.delim -> read.table
Execution halted
ERROR: Command failed with exit status = 1 :

R --vanilla --args MCF7-demo/MCF7-demo_genome.psl MCF7-demo/MCF7-demo.reads /opt/JAFFA/hg38_genCode22.tab /opt/JAFFA/known_fusions.txt 10000 NoSupport,PotentialRegularTranscript MCF7-demo/MCF7-demo.summary < /opt/JAFFA/make_final_table.R
```

The actual issue was that `MCF7-demo/MCF7-demo_genome.psl` was empty
because its processing step had failed, but bpipe was eating the error.
The actual issue was that blat ran out of memory because I only had
2GB memory allocated.

## Testing

I ran this change with enough memory to make `blat` succeed and not
enough memory for `blat` to succeed. In the former the demo worked
and in the latter I got a useful `bpipe` error message and the
pipeline stopped at the appropriate stage.

[1] https://www.gnu.org/software/bash/manual/html_node/Pipelines.html