### PR TITLE
wget command failure to download reference data

### DIFF
--- a/prepare_reference.sh
+++ b/prepare_reference.sh
@@ -9,7 +9,7 @@ JAFFA_DIR=./
 ## For hg38 and gencode49
 GENOME_NAME=hg38
 TRANS_NAME=gencode49
-wget --content-disposition https://figshare.com/ndownloader/files/61624573
+wget --no-check-certificate https://figshare.com/ndownloader/files/61624573
 
 ## For T2T and liftOverGenes uncomment the three lines below
 #GENOME_NAME=hs1

--- a/prepare_reference.sh
+++ b/prepare_reference.sh
@@ -9,7 +9,19 @@ JAFFA_DIR=./
 ## For hg38 and gencode49
 GENOME_NAME=hg38
 TRANS_NAME=gencode49
-wget --no-check-certificate https://figshare.com/ndownloader/files/61624573
+
+if compgen -G "JAFFA_REFERENCE_FILES_*.small.tar.gz" > /dev/null; then
+    echo "Reference archive already exists, skipping download"
+else
+    wget --content-disposition https://figshare.com/ndownloader/files/61624573
+    if ! compgen -G "JAFFA_REFERENCE_FILES_*.small.tar.gz" > /dev/null; then
+        echo "ERROR: Failed to download JAFFA reference archive."
+        echo "Figshare may have returned an empty temporary response instead of the archive."
+        echo "Please download it manually from: https://figshare.com/ndownloader/files/61624573"
+        echo "Then place the downloaded JAFFA_REFERENCE_FILES_*.small.tar.gz file in this directory and rerun this script."
+        exit 1
+    fi
+fi
 
 ## For T2T and liftOverGenes uncomment the three lines below
 #GENOME_NAME=hs1


### PR DESCRIPTION
Fix the wget command
```
wget --content-disposition https://figshare.com/ndownloader/files/61624573
--2026-08-24 16:30:20--  https://figshare.com/ndownloader/files/61624573
Resolving figshare.com (figshare.com)... 108.133.56.201, 3.248.86.171, 34.253.120.123, ...
Connecting to figshare.com (figshare.com)|108.133.56.201|:443... connected.
HTTP request sent, awaiting response... 202 Accepted
Length: 0 [text/html]
Saving to: ‘61624573.8’

61624573.8                                     [ <=>                                                                                   ]       0  --.-KB/s    in 0s      

2026-08-24 16:30:21 (0.00 B/s) - ‘61624573.8’ saved [0/0]
```

using the method listed 
https://github.com/mojaveazure/angsd-wrapper/issues/10#issuecomment-171816491

Tested and it worked on my machine.
